### PR TITLE
fix: 修复画布宽高设置为px以外的单位不会生效的问题

### DIFF
--- a/packages/core/components/designer/src/modules/editContainer/index.vue
+++ b/packages/core/components/designer/src/modules/editContainer/index.vue
@@ -22,8 +22,8 @@ const rootSchema = computed(() => {
 
 const getEditRangestyle = computed(() => {
     return {
-        width: pageSchema.canvas?.width ?? '100%',
-        height: pageSchema.canvas?.height ?? '100%'
+        width: '100%',
+        height: '100%'
     }
 })
 </script>


### PR DESCRIPTION
**问题描述:** 当画布宽度设置非px单位（例如50vw）时会导致画布的位置偏向右侧
**问题分析:** [editScreenContainer.vue](https://github.com/Kchengz/epic-designer/compare/develop...alex-80:epic-designer:upstream?expand=1#diff-0d65639a47445066c38edc1c5da796d3af02c5e36f3d840e95474a20227139ae)中的parseFloat移除了单位，实际上用的还是px